### PR TITLE
merging latest changes from Tom

### DIFF
--- a/schemaDocuments/core/applicationCommon/foundationCommon/crmCommon/solutions/marketing/interactions/ContactCheckedIntoEvent.cdm.json
+++ b/schemaDocuments/core/applicationCommon/foundationCommon/crmCommon/solutions/marketing/interactions/ContactCheckedIntoEvent.cdm.json
@@ -7,7 +7,7 @@
     ],
     "definitions": [
         {
-            "entityName": "EventCheckIn",
+            "entityName": "ContactCheckedIntoEvent",
             "extendsEntity": "CdmObject",
             "exhibitsTraits": {
                 "value": [
@@ -542,6 +542,57 @@
                                 "isNullable": true
                             },
                             {
+                                "name": "eventCheckinId",
+                                "relationship": "hasA",
+                                "dataType": "string",
+                                "appliedTraits": [
+                                    {
+                                        "traitReference": "is.requiredAtLevel",
+                                        "arguments": [
+                                            {
+                                                "name": "level",
+                                                "value": "none"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "traitReference": "is.localized.displayedAs",
+                                        "arguments": [
+                                            {
+                                                "entityReference": {
+                                                    "entityShape": "localizedTable",
+                                                    "constantValues": [
+                                                        [
+                                                            "en",
+                                                            "eventcheckinid"
+                                                        ]
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "traitReference": "is.localized.describedAs",
+                                        "arguments": [
+                                            {
+                                                "entityReference": {
+                                                    "entityShape": "localizedTable",
+                                                    "constantValues": [
+                                                        [
+                                                            "en",
+                                                            "eventcheckinid"
+                                                        ]
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "displayName": "eventcheckinid",
+                                "description": "eventcheckinid",
+                                "isNullable": true
+                            },
+                            {
                                 "name": "contactId",
                                 "relationship": "hasA",
                                 "dataType": "string",
@@ -807,7 +858,7 @@
                                                 "entityShape": "attributeGroupSet",
                                                 "constantValues": [
                                                     [
-                                                        "/core/applicationCommon/foundationCommon/crmCommon/solutions/marketing/interactions/EventCheckin.cdm.json/EventCheckIn/hasAttributes/attributesAddedAtThisScope"
+                                                        "/core/applicationCommon/foundationCommon/crmCommon/solutions/marketing/interactions/ContactCheckedIntoEvent.cdm.json/ContactCheckedIntoEvent/hasAttributes/attributesAddedAtThisScope"
                                                     ]
                                                 ]
                                             }
@@ -820,7 +871,8 @@
                     }
                 }
             ],
-            "displayName": "Event check-in"
+            "displayName": "Event check-in",
+            "sourceName": "EventCheckin"
         }
     ]
 }

--- a/schemaDocuments/core/applicationCommon/foundationCommon/crmCommon/solutions/marketing/interactions/ContactRegisteredToEvent.cdm.json
+++ b/schemaDocuments/core/applicationCommon/foundationCommon/crmCommon/solutions/marketing/interactions/ContactRegisteredToEvent.cdm.json
@@ -542,6 +542,57 @@
                                 "isNullable": true
                             },
                             {
+                                "name": "eventRegistrationId",
+                                "relationship": "hasA",
+                                "dataType": "string",
+                                "appliedTraits": [
+                                    {
+                                        "traitReference": "is.requiredAtLevel",
+                                        "arguments": [
+                                            {
+                                                "name": "level",
+                                                "value": "none"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "traitReference": "is.localized.displayedAs",
+                                        "arguments": [
+                                            {
+                                                "entityReference": {
+                                                    "entityShape": "localizedTable",
+                                                    "constantValues": [
+                                                        [
+                                                            "en",
+                                                            "eventregistrationid"
+                                                        ]
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "traitReference": "is.localized.describedAs",
+                                        "arguments": [
+                                            {
+                                                "entityReference": {
+                                                    "entityShape": "localizedTable",
+                                                    "constantValues": [
+                                                        [
+                                                            "en",
+                                                            "eventregistrationid"
+                                                        ]
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "displayName": "eventregistrationid",
+                                "description": "eventregistrationid",
+                                "isNullable": true
+                            },
+                            {
                                 "name": "contactId",
                                 "relationship": "hasA",
                                 "dataType": "string",


### PR DESCRIPTION
- forced couple more CheckIns into Checkins
- interaction is now named ContactCheckedIntoEvent (I’ve consulted it with or technical writer)
- there is a EventRegistrationId and EventCheckinId fields in the interactions, pointing to the entity in Event Management
