### PR TITLE
Remove Microsoft.Net.Http from net standard dependencies

### DIFF
--- a/objectModel/CSharp/Microsoft.CommonDataModel.ObjectModel/Microsoft.CommonDataModel.ObjectModel.csproj
+++ b/objectModel/CSharp/Microsoft.CommonDataModel.ObjectModel/Microsoft.CommonDataModel.ObjectModel.csproj
@@ -14,9 +14,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-    <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="NLog" Version="4.6.7" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
   </ItemGroup>
 
   <ItemGroup>

--- a/objectModel/CSharp/Microsoft.CommonDataModel.ObjectModel/Microsoft.CommonDataModel.ObjectModel.nuspec
+++ b/objectModel/CSharp/Microsoft.CommonDataModel.ObjectModel/Microsoft.CommonDataModel.ObjectModel.nuspec
@@ -30,7 +30,6 @@
       </group>
       <group targetFramework=".NETStandard2.0">
         <dependency id="Microsoft.CSharp" version="4.5.0" />
-        <dependency id="Microsoft.Net.Http" version="2.2.29" />
         <dependency id="NLog" version="4.6.7" />
         <dependency id="Newtonsoft.Json" version="12.0.2" />
       </group>


### PR DESCRIPTION
The Microsoft.Net.Http package contains no .NET Standard target dlls. Declaring Microsoft.Net.Http as a NET Standard dependency causes this warning on build and for consumers of the produced nuget package:

> D:\ ... \Microsoft.CommonDataModel.ObjectModel.csproj : warning NU1701: Package 'Microsoft.Net.Http 2.2.29' was restored using '.NETFram
ework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8' instead of the project target framewor
k '.NETStandard,Version=v2.0'. This package may not be fully compatible with your project.

The compiled .NET Standard library has no reference to the Microsoft.Net.Http package or the System.Net.Http library.

This change removes Microsoft.Net.Http from the .NET Standard dependencies and package references

