### PR TITLE
Correctly set Int16 or Int64 DataFormat

### DIFF
--- a/objectModel/CSharp/Microsoft.CommonDataModel.ObjectModel/Utilities/TraitToPropertyMap.cs
+++ b/objectModel/CSharp/Microsoft.CommonDataModel.ObjectModel/Utilities/TraitToPropertyMap.cs
@@ -417,12 +417,15 @@ namespace Microsoft.CommonDataModel.ObjectModel.Utilities
 
                 if (baseType == CdmDataFormat.Float && isBig)
                     baseType = CdmDataFormat.Double;
-                if (isInteger && isBig)
-                    baseType = CdmDataFormat.Int64;
-                if (isInteger && isSmall)
-                    baseType = CdmDataFormat.Int16;
-                if (isInteger)
-                    baseType = CdmDataFormat.Int32;
+
+                if (isInteger) {
+                    if (isBig)
+                        baseType = CdmDataFormat.Int64;
+                    else if (isSmall)
+                        baseType = CdmDataFormat.Int16;
+                    else
+                        baseType = CdmDataFormat.Int32;
+                }
             }
 
             return baseType;

--- a/objectModel/Java/objectmodel/src/main/java/com/microsoft/commondatamodel/objectmodel/utilities/TraitToPropertyMap.java
+++ b/objectModel/Java/objectmodel/src/main/java/com/microsoft/commondatamodel/objectmodel/utilities/TraitToPropertyMap.java
@@ -670,14 +670,15 @@ public class TraitToPropertyMap {
       if (CdmDataFormat.Float.equals(baseType) && isBig) {
         baseType = CdmDataFormat.Double;
       }
-      if (isInteger && isBig) {
-        baseType = CdmDataFormat.Int64;
-      }
-      if (isInteger && isSmall) {
-        baseType = CdmDataFormat.Int16;
-      }
+
       if (isInteger) {
-        baseType = CdmDataFormat.Int32;
+          if (isBig) {
+              baseType = CdmDataFormat.Int64;
+          } else if (isSmall) {
+              baseType = CdmDataFormat.Int16;
+          } else {
+              baseType = CdmDataFormat.Int32;
+          }
       }
     }
 

--- a/objectModel/TypeScript/Utilities/traitToPropertyMap.ts
+++ b/objectModel/TypeScript/Utilities/traitToPropertyMap.ts
@@ -389,14 +389,15 @@ export class traitToPropertyMap {
         if (baseType === cdmDataFormat.float && isBig) {
             baseType = cdmDataFormat.double;
         }
-        if (isInteger && isBig) {
-            baseType = cdmDataFormat.int64;
-        }
-        if (isInteger && isSmall) {
-            baseType = cdmDataFormat.int16;
-        }
+
         if (isInteger) {
-            baseType = cdmDataFormat.int32;
+            if (isBig) {
+                baseType = cdmDataFormat.int64;
+            } else if (isSmall) {
+                baseType = cdmDataFormat.int16;
+            } else {
+                baseType = cdmDataFormat.int32;
+            }
         }
 
         return baseType;


### PR DESCRIPTION
Inside `TraitsToDataFormat`, the last `if (isInteger)` condition will
overwrite other integer datatypes (like Int16 and Int64) to Int32.

This patch fixes the issue.