### PR TITLE
Loosen lazy-object-pin

### DIFF
--- a/objectModel/Python/requirements.txt
+++ b/objectModel/Python/requirements.txt
@@ -9,7 +9,7 @@ colorama==0.4.3
 cryptography==3.4.7
 idna==2.8
 importlib-metadata==1.0
-lazy-object-proxy>=1.3.1<=1.6.0
+lazy-object-proxy>=1.3.1,<=1.6.0
 nest-asyncio==1.4.3
 msal==1.11.0
 mccabe==0.6.1

--- a/objectModel/Python/requirements.txt
+++ b/objectModel/Python/requirements.txt
@@ -9,7 +9,7 @@ colorama==0.4.3
 cryptography==3.4.7
 idna==2.8
 importlib-metadata==1.0
-lazy-object-proxy==1.3.1
+lazy-object-proxy>=1.3.1<=1.6.0
 nest-asyncio==1.4.3
 msal==1.11.0
 mccabe==0.6.1


### PR DESCRIPTION
This pin is blocking support for Python >=3.7.

lazy-object-proxy==1.3.1, is only available for Python <=3.6