### PR TITLE
Allow legitimate falsy values in argument value

### DIFF
--- a/objectModel/TypeScript/Cdm/CdmArgumentDefinition.ts
+++ b/objectModel/TypeScript/Cdm/CdmArgumentDefinition.ts
@@ -89,7 +89,7 @@ export class CdmArgumentDefinition extends cdmObjectSimple {
     public validate(): boolean {
         // let bodyCode = () =>
         {
-            if (!this.value) {
+            if (this.value === null || this.value === undefined || this.value = NaN) {
                 let missingFields: string[] = ['value'];
                 Logger.error(this.ctx, this.TAG, this.validate.name, this.atCorpusPath, cdmLogCode.ErrValdnIntegrityCheckFailure, missingFields.map((s: string) => `'${s}'`).join(', '), this.atCorpusPath);
                 return false;


### PR DESCRIPTION
This change allows for empty string (`''`, `""`), `0`, and `false` to be set as the `value` in `CdmArgumentDefinition` without causing a validation error.