### PR TITLE
Correct spelling errors

### DIFF
--- a/schemaDocuments/meanings.measurement.cdm.json
+++ b/schemaDocuments/meanings.measurement.cdm.json
@@ -57,7 +57,7 @@
     },
     {
       "traitName": "means.measurement.dimension.electricCurrent",
-      "explanation": "measurement of electic current",
+      "explanation": "measurement of electric current",
       "extendsTrait": {
         "traitReference": "means.measurement.dimension",
         "arguments": [
@@ -87,7 +87,7 @@
     },
     {
       "traitName": "means.measurement.dimension.luminousIntensity",
-      "explanation": "measurement of electic current",
+      "explanation": "measurement of electric current",
       "extendsTrait": {
         "traitReference": "means.measurement.dimension",
         "arguments": [
@@ -177,7 +177,7 @@
     },
     {
       "traitName": "means.measurement.dimension.capacitance",
-      "explanation": "measurement of electical capacitance",
+      "explanation": "measurement of electrical capacitance",
       "extendsTrait": {
         "traitReference": "means.measurement.dimension",
         "arguments": [


### PR DESCRIPTION
Fix spelling of "electric" and "electrical".