### PR TITLE
Relax Regex requirement to include another version 2021.3.17

### DIFF
--- a/objectModel/Python/requirements.txt
+++ b/objectModel/Python/requirements.txt
@@ -2,5 +2,5 @@ nest-asyncio>=1.4.3,<2
 msal>=1.14.0,<2
 python-dateutil>=2.8.0
 msrest>=0.6.21
-regex==2020.11.13
+regex>=2020.11.13,<=2021.3.17
 


### PR DESCRIPTION
In Anaconda3 (Anaconda3-2021.05-Linux-x86_64.sh), Regex does not include the required version 2020.11.13. So in the isolated environment, CDM library(v1.6.1) fails to load. This PR is to add one more version 2021.3.17 to support it.