### PR TITLE
Fix x-ms-request-id header null reference

### DIFF
--- a/objectModel/CSharp/Microsoft.CommonDataModel.ObjectModel.Tests/Microsoft.CommonDataModel.ObjectModel.Tests.csproj
+++ b/objectModel/CSharp/Microsoft.CommonDataModel.ObjectModel.Tests/Microsoft.CommonDataModel.ObjectModel.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/objectModel/CSharp/Microsoft.CommonDataModel.ObjectModel/Utilities/Network/CdmHttpClient.cs
+++ b/objectModel/CSharp/Microsoft.CommonDataModel.ObjectModel/Utilities/Network/CdmHttpClient.cs
@@ -177,7 +177,13 @@ namespace Microsoft.CommonDataModel.ObjectModel.Utilities.Network
                         {
                             contentLength = response.Content.Headers.ContentLength.ToString();
                         }
-                        string adlsRequestId = response?.Headers.GetValues("x-ms-request-id").FirstOrDefault();
+
+                        string adlsRequestId = string.Empty;
+                        if (response?.Content.Headers.Contains("x-ms-request-id") == true)
+                        {
+                            adlsRequestId = response?.Headers.GetValues("x-ms-request-id").FirstOrDefault();
+                        }
+                        
                         Logger.Info(ctx, Tag, nameof(SendAsyncHelper), null, $"Response for request id: {adlsRequestId}, elapsed time: {endTime.Subtract(startTime).TotalMilliseconds} ms, content length: {contentLength}, status code: {response.StatusCode}.");
                     }
 

--- a/objectModel/Java/objectmodel/src/main/java/com/microsoft/commondatamodel/objectmodel/utilities/network/CdmHttpClient.java
+++ b/objectModel/Java/objectmodel/src/main/java/com/microsoft/commondatamodel/objectmodel/utilities/network/CdmHttpClient.java
@@ -174,7 +174,7 @@ public class CdmHttpClient {
                     final Instant endTime = java.time.Instant.now();
                     Logger.info(ctx, TAG, "sendAsyncHelper",
                             null, Logger.format("Response for request id: {0}, elapsed time: {1} ms, content length: {2}, status code: {3}.",
-                            response.getFirstHeader("x-ms-request-id").getValue(),
+                            response.getFirstHeader("x-ms-request-id") != null ? response.getFirstHeader("x-ms-request-id").getValue() : "",
                             Duration.between(startTime, endTime).toMillis(),
                             response.getEntity() != null ? response.getEntity().getContentLength() : "",
                             response.getStatusLine() != null ? response.getStatusLine().getStatusCode() : ""

--- a/objectModel/TestData/Utilities/TestHttpClient/Input/default.manifest.cdm.json
+++ b/objectModel/TestData/Utilities/TestHttpClient/Input/default.manifest.cdm.json
@@ -1,0 +1,11 @@
+{
+    "manifestName": "default.manifest.cdm.json",
+    "entities": [],
+    "jsonSchemaSemanticVersion": "1.0.0",
+    "imports": [
+      {
+        "corpusPath": "cdm:/foundations.cdm.json",
+        "moniker": ""
+      }
+    ]
+  }


### PR DESCRIPTION
This fix addresses a null reference issue in the CdmHttpClient class.

When attempting to use the `NetworkAdapter` to access files on a host, if the host does not return the `x-ms-request-id` header in the response, a null reference exception would be thrown. This change fixes the null reference exception by checking to see if the header exists in the response before attempting to access the value.

This change also includes a test which will now pass, given that the fix is in place.

In order to run the tests, a reference to `Moq` needed to be added to the Tests project.