### PR TITLE
Fix update process for DisplayName and Description properties

### DIFF
--- a/objectModel/CSharp/Microsoft.CommonDataModel.ObjectModel.Tests/Persistence/CdmFolder/EntityAttribute/CdmEntityAttributePersistenceTests.cs
+++ b/objectModel/CSharp/Microsoft.CommonDataModel.ObjectModel.Tests/Persistence/CdmFolder/EntityAttribute/CdmEntityAttributePersistenceTests.cs
@@ -41,5 +41,35 @@ namespace Microsoft.CommonDataModel.ObjectModel.Tests.Persistence.CdmFolder
             // Checks if there is no residue of the transformation of the properties into traits.
             Assert.IsNull(data.AppliedTraits);
         }
+
+        /// <summary>
+        /// Tests if updating the properties description and displayName will persist
+        /// </summary>
+        [TestMethod]
+        public void TestUpdatingDescriptionAndDisplayName()
+        {
+            var corpus = new CdmCorpusDefinition();
+            var entityName = "TheEntity";
+            var description = "entityAttributeDescription";
+            var displayName = "whatABeutifulDisplayName";
+            var inputData = new JObject() 
+            {
+                ["name"] = entityName,
+                ["displayName"] = displayName,
+                ["description"] = description
+            };
+
+            var instance = EntityAttributePersistence.FromData(corpus.Ctx, inputData);
+
+            var newDescription = "newEntityAttributeDescription";
+            var newDisplayName = "anotherBeautifulDisplanyName";
+
+            instance.Description = newDescription;
+            instance.DisplayName = newDisplayName;
+
+            // Make sure the properties got updated on the instance correctly
+            Assert.AreEqual(newDescription, instance.Description);
+            Assert.AreEqual(newDisplayName, instance.DisplayName);
+        }
     }
 }

--- a/objectModel/CSharp/Microsoft.CommonDataModel.ObjectModel/Cdm/CdmConstantEntityDefinition.cs
+++ b/objectModel/CSharp/Microsoft.CommonDataModel.ObjectModel/Cdm/CdmConstantEntityDefinition.cs
@@ -141,7 +141,7 @@ namespace Microsoft.CommonDataModel.ObjectModel.Cdm
         internal string UpdateConstantValue(ResolveOptions resOpt, dynamic attReturn, string newValue, dynamic attSearch, string valueSearch, int order)
         {
             string result = null;
-            Func<string, string> action = found => { result = found; return found; };
+            Func<string, string> action = found => { result = newValue; return newValue; };
             this.FindValue(resOpt, attReturn, attSearch, valueSearch, order, action);
             return result;
         }


### PR DESCRIPTION
When updating `DisplayName` or `Description` (the only two `localizedTraitTable`-backed properties), changes were not persisting. It looks like there was a bug in the `UpdateConstantValue` method which caused the original value to be written back onto the property instead of the new value.

This change fixes the behavior to act as intended (and as described in the comments which were already on the method).

This change also provides a test which covers this scenario and checks that these two properties update correctly when set through the SDK.