### PR TITLE
Fix reading the primary key property of resolved entities

### DIFF
--- a/objectModel/CSharp/Microsoft.CommonDataModel.ObjectModel.Tests/Utilities/TraitToPropertyMapTests.cs
+++ b/objectModel/CSharp/Microsoft.CommonDataModel.ObjectModel.Tests/Utilities/TraitToPropertyMapTests.cs
@@ -103,6 +103,33 @@ namespace Microsoft.CommonDataModel.ObjectModel.Tests.Utilities
         }
 
         /// <summary>
+        /// Test fetching primary key of a resolved entity from an abstract manifest.
+        /// </summary>
+        [TestMethod]
+        public async Task TestFetchAbstractPrimaryKey()
+        {
+            var corpus = TestHelper.GetLocalCorpus(testsSubpath, nameof(TestFetchAbstractPrimaryKey));
+            var doc = await corpus.FetchObjectAsync<CdmDocumentDefinition>("Account.cdm.json");
+
+            if (doc == null)
+            {
+                Assert.Fail($"Unable to load acccount.cdm.json. Please inspect error log for additional details.");
+            }
+
+            var entity = (CdmEntityDefinition)doc.Definitions[0];
+            var resolvedEntity = await entity.CreateResolvedEntityAsync("ResolvedAccount");
+            try
+            {
+                var pk = resolvedEntity.PrimaryKey;
+                Assert.IsNotNull(pk);
+            }
+            catch (Exception e)
+            {
+                Assert.Fail($"Exception occur while reading primary key for entity account. {e.Message}");
+            }
+        }
+
+        /// <summary>
         /// Test setting and getting of data format
         /// </summary>
         [TestMethod]

--- a/objectModel/CSharp/Microsoft.CommonDataModel.ObjectModel/Utilities/TraitToPropertyMap.cs
+++ b/objectModel/CSharp/Microsoft.CommonDataModel.ObjectModel/Utilities/TraitToPropertyMap.cs
@@ -203,7 +203,7 @@ namespace Microsoft.CommonDataModel.ObjectModel.Utilities
                         {
                             return attRef;
                         }
-                        return ((CdmTypeAttributeDefinition)attRef).FetchObjectDefinitionName();
+                        return ((CdmObject)attRef).FetchObjectDefinitionName();
                     }
                     break;
                 case "defaultValue":

--- a/objectModel/TestData/Utilities/TraitToPropertyMap/TestFetchAbstractPrimaryKey/Input/Account.cdm.json
+++ b/objectModel/TestData/Utilities/TraitToPropertyMap/TestFetchAbstractPrimaryKey/Input/Account.cdm.json
@@ -1,0 +1,20 @@
+{
+  "jsonSchemaSemanticVersion": "1.0.0",
+  "imports": [
+    {
+      "corpusPath": "cdm:/foundations.cdm.json"
+    }
+  ],
+  "definitions": [
+    {
+      "entityName": "Account",
+      "hasAttributes": [
+        {
+          "name": "accountId",
+          "purpose": "identifiedBy",
+          "dataType": "entityId"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This change fixes an issue where, when reading the `PrimaryKey` property of an entity which was resolved from an abstract manifest (with the `identifiedBy` purpose on an attribute), the value cannot be retrieved.

When `FetchTraitReferenceArgumentValue` returns the value of the argument for the resolved `is.identifiedBy` trait, it returns either a `string` or a `CdmAttributeReference`. However, the subsequent process was looking to cast to a `CdmTypeAttributeDefinition`, which is not a compatible type. Since the only thing the code needs from that object is the name, it is safe to cast to the `CdmObject` instead and call the underlying `FetchObjectDefinitionName()` method. 

This change makes the cast to `CdmObject` and returns the value successfully.

A unit test which addresses this situation is also included in the changes.