### PR TITLE
Fix failing unit tests on Mac

### DIFF
--- a/objectModel/CSharp/Microsoft.CommonDataModel.ObjectModel.Tests/Cdm/Relationship/RelationshipTest.cs
+++ b/objectModel/CSharp/Microsoft.CommonDataModel.ObjectModel.Tests/Cdm/Relationship/RelationshipTest.cs
@@ -268,7 +268,7 @@ namespace Microsoft.CommonDataModel.ObjectModel.Tests.Cdm
             var corpus = TestHelper.GetLocalCorpus(testsSubpath, "TestRelationshipToDifferentNamespace");
 
             // entity B will be in a different namespace
-            corpus.Storage.Mount("differentNamespace", new LocalAdapter($"{TestHelper.GetInputFolderPath(testsSubpath, "TestRelationshipToDifferentNamespace")}\\differentNamespace"));
+            corpus.Storage.Mount("differentNamespace", new LocalAdapter($"{TestHelper.GetInputFolderPath(testsSubpath, "TestRelationshipToDifferentNamespace")}/differentNamespace"));
 
             var manifest = await corpus.FetchObjectAsync<CdmManifestDefinition>("local:/main.manifest.cdm.json");
 

--- a/objectModel/CSharp/Microsoft.CommonDataModel.ObjectModel.Tests/Persistence/ModelJson/DataPartitionTests.cs
+++ b/objectModel/CSharp/Microsoft.CommonDataModel.ObjectModel.Tests/Persistence/ModelJson/DataPartitionTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CommonDataModel.ObjectModel.Tests.Persistence.ModelJson
             var convertedToModelJson = await modelJsonPersistence.ManifestPersistence.ToData(manifestRead, null, null);
             string location = (convertedToModelJson.Entities[0]["partitions"][0]["location"] as JValue).Value<string>();
             // Model Json uses absolute adapter path.
-            Assert.IsTrue(location.Contains("\\TestData\\Persistence\\ModelJson\\DataPartition\\TestModelJsonDataPartitionLocationConsistency\\Input\\EpisodeOfCare\\partition-data.csv"));
+            Assert.IsTrue(location.Contains(Path.Combine("TestData", "Persistence", "ModelJson", "DataPartition", "TestModelJsonDataPartitionLocationConsistency", "Input", "EpisodeOfCare", "partition-data.csv")));
 
             var cdmCorpus2 = TestHelper.GetLocalCorpus(testsSubpath, "TestModelJsonDataPartitionLocationConsistency");
             var manifestAfterConvertion = await modelJsonPersistence.ManifestPersistence.FromObject(cdmCorpus2.Ctx, convertedToModelJson, cdmCorpus2.Storage.FetchRootFolder("local"));

--- a/objectModel/CSharp/Microsoft.CommonDataModel.ObjectModel.Tests/Storage/LocalAdapterTests.cs
+++ b/objectModel/CSharp/Microsoft.CommonDataModel.ObjectModel.Tests/Storage/LocalAdapterTests.cs
@@ -3,6 +3,8 @@
 
 namespace Microsoft.CommonDataModel.ObjectModel.Tests.Storage
 {
+    using System;
+    using System.IO;
     using Microsoft.CommonDataModel.ObjectModel.Storage;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -15,11 +17,16 @@ namespace Microsoft.CommonDataModel.ObjectModel.Tests.Storage
         [TestMethod]
         public void TestCreateAdapterPath()
         {
-            var adapter = new LocalAdapter("C:/some/dir");
+            string rootPath = OperatingSystem.IsWindows() ? "C:\\" : "/";
+            string fullPath = Path.Combine(rootPath, "some", "dir");
+
+            var adapter = new LocalAdapter(fullPath);
             string pathWithLeadingSlash = adapter.CreateAdapterPath("/folder");
             string pathWithoutLeadingSlash = adapter.CreateAdapterPath("folder");
 
-            Assert.AreEqual(pathWithLeadingSlash, "C:\\some\\dir\\folder");
+            string fullPathWithFolder = Path.Combine(fullPath, "folder");
+
+            Assert.AreEqual(pathWithLeadingSlash, fullPathWithFolder);
             Assert.AreEqual(pathWithLeadingSlash, pathWithoutLeadingSlash);
 
             // A null corpus path should return a null adapter path

--- a/objectModel/CSharp/Microsoft.CommonDataModel.ObjectModel/Persistence/ModelJson/ManifestPersistence.cs
+++ b/objectModel/CSharp/Microsoft.CommonDataModel.ObjectModel/Persistence/ModelJson/ManifestPersistence.cs
@@ -7,6 +7,7 @@ namespace Microsoft.CommonDataModel.ObjectModel.Persistence.ModelJson
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Text.RegularExpressions;
     using System.Threading.Tasks;
 
     using Microsoft.CommonDataModel.ObjectModel.Cdm;
@@ -291,8 +292,9 @@ namespace Microsoft.CommonDataModel.ObjectModel.Persistence.ModelJson
                     var referenceModelIdAsString = referenceModelId.ToString();
                     var referenceModelLocation = referenceModel["location"];
                     var referenceModelLocationAsString = referenceModelLocation.ToString();
-                    referenceModels.Add(referenceModelIdAsString, referenceModelLocationAsString);
-                    referenceEntityLocations.Add(referenceModelLocationAsString, referenceModelIdAsString);
+                    var referenceModelLocationAsStringNormalized = Regex.Replace(referenceModelLocationAsString, @"\\+", "/");
+                    referenceModels.Add(referenceModelIdAsString, referenceModelLocationAsStringNormalized);
+                    referenceEntityLocations.Add(referenceModelLocationAsStringNormalized, referenceModelIdAsString);
                 }
             }
 

--- a/objectModel/TestData/Storage/TestLoadingConfigAndTryingToFetchManifest/Input/config-CSharp.json
+++ b/objectModel/TestData/Storage/TestLoadingConfigAndTryingToFetchManifest/Input/config-CSharp.json
@@ -5,7 +5,7 @@
       "type": "local",
       "namespace": "local",
         "config": {
-            "root": "../../../../../TestData\\Storage\\TestLoadingConfigAndTryingToFetchManifest\\Input\\SubFolder"
+            "root": "../../../../../TestData/Storage/TestLoadingConfigAndTryingToFetchManifest/Input/SubFolder"
         }
     },
     {

--- a/objectModel/TestData/Storage/TestLoadingConfigAndTryingToFetchManifest/Input/config-Java.json
+++ b/objectModel/TestData/Storage/TestLoadingConfigAndTryingToFetchManifest/Input/config-Java.json
@@ -5,7 +5,7 @@
       "type": "local",
       "namespace": "local",
         "config": {
-            "root": "../../TestData\\Storage\\TestLoadingConfigAndTryingToFetchManifest\\Input\\SubFolder"
+            "root": "../../TestData/Storage/TestLoadingConfigAndTryingToFetchManifest/Input/SubFolder"
         }
     },
     {

--- a/objectModel/TestData/Storage/TestLoadingConfigAndTryingToFetchManifest/Input/config-Python.json
+++ b/objectModel/TestData/Storage/TestLoadingConfigAndTryingToFetchManifest/Input/config-Python.json
@@ -5,7 +5,7 @@
       "type": "local",
       "namespace": "local",
         "config": {
-            "root": "../TestData\\Storage\\TestLoadingConfigAndTryingToFetchManifest\\Input\\SubFolder"
+            "root": "../TestData/Storage/TestLoadingConfigAndTryingToFetchManifest/Input/SubFolder"
         }
     },
     {

--- a/objectModel/TestData/Storage/TestLoadingConfigAndTryingToFetchManifest/Input/config-TypeScript.json
+++ b/objectModel/TestData/Storage/TestLoadingConfigAndTryingToFetchManifest/Input/config-TypeScript.json
@@ -5,7 +5,7 @@
       "type": "local",
       "namespace": "local",
         "config": {
-            "root": "../TestData\\Storage\\TestLoadingConfigAndTryingToFetchManifest\\Input\\SubFolder"
+            "root": "../TestData/Storage/TestLoadingConfigAndTryingToFetchManifest/Input/SubFolder"
         }
     },
     {


### PR DESCRIPTION
A handful of tests fail on Mac due to path format incompatibilities. These changes update tests and make them cross-platform compatible.